### PR TITLE
Optimize memory usage of the native wrapper

### DIFF
--- a/src/main/java/io/sqreen/powerwaf/CharSequenceWrapper.java
+++ b/src/main/java/io/sqreen/powerwaf/CharSequenceWrapper.java
@@ -14,6 +14,7 @@ public class CharSequenceWrapper {
     private static boolean resetBuffer;
 
     static {
+        // Get the package private class StringCharBuffer by calling wrap
         str = getField(CharBuffer.wrap("").getClass(), "str");
         offset = getField(CharBuffer.class, "offset");
         mark = getField(Buffer.class, "mark");
@@ -38,7 +39,8 @@ public class CharSequenceWrapper {
         if (!resetBuffer || previous == null || cs == null) {
             return CharBuffer.wrap(cs);
         } else {
-            // we're assuming that this is a StringCharBuffer until proven otherwise
+            // Since StringCharBuffer is package private, we can't do an instanceof check above, so we're
+            // assuming that this is a StringCharBuffer and catch any exceptions, and don't try again
             try {
                 str.set(previous, cs);
                 offset.setInt(previous, 0);

--- a/src/main/java/io/sqreen/powerwaf/CharSequenceWrapper.java
+++ b/src/main/java/io/sqreen/powerwaf/CharSequenceWrapper.java
@@ -1,0 +1,57 @@
+package io.sqreen.powerwaf;
+
+import java.lang.reflect.Field;
+import java.nio.Buffer;
+import java.nio.CharBuffer;
+
+public class CharSequenceWrapper {
+    private static final Field str;
+    private static final Field offset;
+    private static final Field mark;
+    private static final Field position;
+    private static final Field limit;
+    private static final Field capacity;
+    private static boolean resetBuffer;
+
+    static {
+        str = getField(CharBuffer.wrap("").getClass(), "str");
+        offset = getField(CharBuffer.class, "offset");
+        mark = getField(Buffer.class, "mark");
+        position = getField(Buffer.class, "position");
+        limit = getField(Buffer.class, "limit");
+        capacity = getField(Buffer.class, "capacity");
+        resetBuffer = str != null && offset != null && mark != null && position != null
+                && limit != null && capacity != null;
+    }
+
+    private static Field getField(Class<?> klass, String name) {
+        try {
+            Field f = klass.getDeclaredField(name);
+            f.setAccessible(true);
+            return f;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    public static CharBuffer wrap(CharSequence cs, CharBuffer previous) {
+        if (!resetBuffer || previous == null || cs == null) {
+            return CharBuffer.wrap(cs);
+        } else {
+            // we're assuming that this is a StringCharBuffer until proven otherwise
+            try {
+                str.set(previous, cs);
+                offset.setInt(previous, 0);
+                mark.setInt(previous, -1);
+                position.setInt(previous, 0);
+                int len = cs.length();
+                limit.setInt(previous, len);
+                capacity.setInt(previous, len);
+                return previous;
+            } catch (Throwable t) {
+                resetBuffer = false;
+                return CharBuffer.wrap(cs);
+            }
+        }
+    }
+}

--- a/src/main/java/io/sqreen/powerwaf/Powerwaf.java
+++ b/src/main/java/io/sqreen/powerwaf/Powerwaf.java
@@ -142,6 +142,9 @@ public final class Powerwaf {
     }
 
     public static class ActionWithData {
+        // reuse this from JNI when there is no Action or Data
+        public static final ActionWithData OK_NULL = new ActionWithData(Action.OK, null);
+
         public final Action action;
         public final String data;
 


### PR DESCRIPTION
This drops the memory usage for the JMH benchmark in `dd-trace-java` with 10 headers from ~12k per request to ~4k per request with almost all overhead now being on the AppSec library side.