### PR TITLE
Use cmake -B

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(libsqreen_java)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12.0)
 
 include(FindJNI)
 if (JNI_FOUND)

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ task cmakeNativeLibDebug(type: Exec) {
     if (WINDOWS) {
         commandLine 'cmake', "-DCMAKE_PREFIX_PATH=$pwafConfDir", projectDir
     } else {
-        commandLine('cmake', '-DCMAKE_BUILD_TYPE=Debug', "-DCMAKE_PREFIX_PATH=$pwafConfDir",
+        commandLine('cmake', '-B', '.', '-DCMAKE_BUILD_TYPE=Debug', "-DCMAKE_PREFIX_PATH=$pwafConfDir",
                              *cmakeOpts, projectDir)
     }
 


### PR DESCRIPTION
Use cmake -B . Otherwise, cmake 3.26 on Linux generates build files in the project root rather than build/Debug. This requires cmake 3.12 but that should be ok since our builders use cmake 3.24.