### PR TITLE
Move cmake_minimum_required to the top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libsqreen_java)
 cmake_minimum_required(VERSION 2.8.12)
+project(libsqreen_java)
 
 include(FindJNI)
 if (JNI_FOUND)


### PR DESCRIPTION
Prevents a related warning, see https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html