### PR TITLE
Update to version 1.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,15 @@ if(NOT(MSVC))
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-	add_compile_options(-Wno-declaration-after-statement -Wno-reserved-identifier -Wno-implicit-fallthrough)
+    add_compile_options(-Wno-declaration-after-statement -Wno-reserved-identifier
+        -Wno-implicit-fallthrough -Wno-gnu-auto-type -Wno-c++98-compat)
 endif()
 
 set(SOURCE_FILES
     src/main/c/byte_buffer.c
     src/main/c/cs_wrapper.c
     src/main/c/debug_helpers.c
+    src/main/c/output.c
     src/main/c/powerwaf_jni.c
     src/main/c/java_call.c
     src/main/c/metrics.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.12.0)
 project(libsqreen_java)
-cmake_minimum_required(VERSION 2.8.12)
 
 include(FindJNI)
 if (JNI_FOUND)

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 group 'io.sqreen'
-version '6.3.0'
+version '7.0.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -85,10 +85,10 @@ task cmakeNativeLibDebug(type: Exec) {
     }
 
     if (WINDOWS) {
-        commandLine 'cmake', "-DCMAKE_PREFIX_PATH=$pwafConfDir", projectDir
+        commandLine 'cmake', "-DCMAKE_PREFIX_PATH=$pwafConfDir", '-S', projectDir, '-B', '.'
     } else {
         commandLine('cmake', '-DCMAKE_BUILD_TYPE=Debug', "-DCMAKE_PREFIX_PATH=$pwafConfDir",
-                             *cmakeOpts, projectDir)
+                             *cmakeOpts, '-S', projectDir, '-B', '.')
     }
 
     workingDir "$buildDir/Debug"

--- a/src/main/c/json.h
+++ b/src/main/c/json.h
@@ -1,0 +1,183 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog
+ * (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
+ */
+
+#pragma once
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#define MIN_JSON_SEGMENT_SIZE ((uint32_t) 216)
+#define MAX_JSON_DEPTH 10
+
+struct json_segment {
+    uint32_t size, len;
+    struct json_segment *next;
+    char data[];
+};
+
+struct json_iterator {
+    const struct json_segment *seg;
+    uint32_t pos;
+};
+
+static inline size_t json_length(const struct json_segment *seg)
+{
+    size_t res = 0;
+    for (const struct json_segment *p = seg; p; p = p->next) {
+        res += p->len;
+    }
+    return res;
+}
+
+static inline size_t json_it_read(struct json_iterator *it, char *out,
+                                  size_t out_len)
+{
+    size_t written = 0;
+    while (it->seg != NULL && written < out_len) {
+        uint32_t avail_in_seg = it->seg->len - it->pos;
+        if (avail_in_seg == 0) {
+            it->seg = it->seg->next;
+            it->pos = 0;
+            continue;
+        }
+        size_t left_in_out = out_len - written;
+        size_t to_copy =
+                avail_in_seg < left_in_out ? avail_in_seg : left_in_out;
+        memcpy(out + written, it->seg->data + it->pos, to_copy);
+        it->pos += to_copy;
+        written += to_copy;
+    }
+    return written;
+}
+
+static inline struct json_segment *json_seg_new(size_t min_size)
+{
+    if (min_size > UINT32_MAX) {
+        return NULL;
+    }
+
+    uint32_t size = ((uint32_t) min_size) < MIN_JSON_SEGMENT_SIZE
+                            ? MIN_JSON_SEGMENT_SIZE
+                            : (uint32_t) min_size;
+
+    _Static_assert(sizeof(size_t) > sizeof(size), "size_t is more than 32 bit");
+    struct json_segment *initial_seg = malloc(sizeof *initial_seg + size);
+    if (!initial_seg) {
+        return NULL;
+    }
+    initial_seg->size = size;
+    initial_seg->len = 0;
+    initial_seg->next = 0;
+    return initial_seg;
+}
+
+static inline struct json_segment *_json_seg_ensure(struct json_segment *seg,
+                                                    size_t data_len)
+{
+    if (seg == NULL) {
+        return NULL;
+    }
+    if (data_len > UINT32_MAX) {
+        return NULL;
+    }
+
+    uint32_t avail = seg->size - seg->len;
+    if (avail >= data_len) {
+        return seg;
+    } else {
+        struct json_segment *new_seg = json_seg_new(data_len);
+        if (!new_seg) {
+            return NULL;
+        }
+        seg->next = new_seg;
+        return new_seg;
+    }
+}
+
+static inline struct json_segment *
+json_append(struct json_segment *seg, const char *data, size_t data_len)
+{
+    struct json_segment *actual_seg = _json_seg_ensure(seg, data_len);
+    if (actual_seg == NULL) {
+        return NULL;
+    }
+
+    memcpy(actual_seg->data + actual_seg->len, data, data_len);
+    actual_seg->len += data_len;
+    return actual_seg;
+}
+
+static inline void json_seg_free(struct json_segment *seg)
+{
+    struct json_segment *cur = seg;
+    struct json_segment *next;
+    while (cur) {
+        next = cur->next;
+        free(cur);
+        cur = next;
+    }
+}
+static inline size_t _json_str_encoded_size(const char *str, size_t str_len)
+{
+    size_t res = 0;
+    for (const char *c = str; c < str + str_len; c++) {
+        if (*c == '\\' || *c == '"') {
+            res += 2;
+        } else if (*c >= 0 && *c < 0x20) {
+            res += 6; /* \uXXXX */
+        } else {
+            res += 1;
+        }
+    }
+    return res;
+}
+static inline void _json_encode_str(const char *str, size_t str_len, char *out)
+{
+    char *o = out;
+    for (const char *c = str; c < str + str_len; c++) {
+        if (*c == '\\' || *c == '"') {
+            o[0] = '\\';
+            o[1] = *c;
+            o += 2;
+        } else if (*c >= 0 && *c < 0x20) {
+            char s[3];
+            sprintf(s, "%02X", *c);
+            o[0] = '\\';
+            o[1] = 'u';
+            o[2] = '0';
+            o[3] = '0';
+            o[4] = s[0];
+            o[5] = s[1];
+            o += 6; /* \uXXXX */
+        } else {
+            *o = *c;
+            o += 1;
+        }
+    }
+}
+
+static inline struct json_segment *json_encode_str(struct json_segment *seg,
+                                                   const char *raw_str,
+                                                   size_t raw_str_len)
+{
+    size_t encoded_len = _json_str_encoded_size(raw_str, raw_str_len);
+    struct json_segment *cur_seg = _json_seg_ensure(seg, encoded_len);
+    if (!cur_seg) {
+        return NULL;
+    }
+    if (encoded_len == raw_str_len) {
+        // can be copied as is
+        memcpy(cur_seg->data + cur_seg->len, raw_str, raw_str_len);
+    } else {
+        _json_encode_str(raw_str, raw_str_len, cur_seg->data + cur_seg->len);
+    }
+    cur_seg->len += encoded_len;
+    return cur_seg;
+}

--- a/src/main/c/output.c
+++ b/src/main/c/output.c
@@ -1,0 +1,461 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog
+ * (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
+ */
+
+#include "output.h"
+#include <assert.h>
+#include <ddwaf.h>
+#include <stdint.h>
+#include <string.h>
+#include <inttypes.h>
+#include <limits.h>
+
+#include "common.h"
+#include "java_call.h"
+#include "jni.h"
+#include "json.h"
+#include "utf16_utf8.h"
+
+#define LSTR(x) "" x, sizeof(x) - 1
+#define MAX_JINT ((jint) 0x7FFFFFFF)
+
+static struct j_method _rsi_init;
+static struct j_method _sect_info_err_init;
+static struct j_method _sect_info_normal_init;
+static struct j_method _array_list_init;
+static struct j_method _array_list_add;
+static struct j_method _linked_hm_init;
+static struct j_method _map_put;
+
+static jstring _map_get_string_checked(JNIEnv *env, const ddwaf_object *obj,
+                                       const char *str, size_t str_len);
+static jobject _convert_section_checked(JNIEnv *env, const ddwaf_object *root,
+                                        const char *sect_name, size_t sect_len);
+static jobject _convert_strarr_checked(JNIEnv *env, const ddwaf_object *o);
+static struct json_segment *_convert_json(const ddwaf_object *cur_obj,
+                                          int depth,
+                                          struct json_segment *cur_seg);
+
+jobject output_convert_diagnostics_checked(JNIEnv *env, const ddwaf_object *obj)
+{
+    jstring rulesetVersion =
+            _map_get_string_checked(env, obj, LSTR("ruleset_version"));
+    if (JNI(ExceptionCheck)) {
+        return NULL;
+    }
+
+    jobject rules = NULL, custom_rules = NULL, rules_data = NULL,
+            rules_override = NULL, exclusions = NULL, ret = NULL;
+
+    rules = _convert_section_checked(env, obj, LSTR("rules"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+    custom_rules = _convert_section_checked(env, obj, LSTR("custom_rules"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+    rules_data = _convert_section_checked(env, obj, LSTR("rules_data"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+    rules_override = _convert_section_checked(env, obj, LSTR("rules_override"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+    exclusions = _convert_section_checked(env, obj, LSTR("exclusions"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+
+    ret = java_meth_call(env, &_rsi_init, NULL, rulesetVersion, rules,
+                         custom_rules, rules_data, rules_override, exclusions);
+
+err:
+    if (rulesetVersion) {
+        JNI(DeleteLocalRef, rulesetVersion);
+    }
+    if (rules) {
+        JNI(DeleteLocalRef, rules);
+    }
+    if (custom_rules) {
+        JNI(DeleteLocalRef, custom_rules);
+    }
+    if (rules_data) {
+        JNI(DeleteLocalRef, rules_data);
+    }
+    if (rules_override) {
+        JNI(DeleteLocalRef, rules_override);
+    }
+    if (exclusions) {
+        JNI(DeleteLocalRef, exclusions);
+    }
+    return ret;
+}
+
+void output_init_checked(JNIEnv *env)
+{
+    if (!java_meth_init_checked(env, &_rsi_init,
+                                "io/sqreen/powerwaf/RuleSetInfo", "<init>",
+                                "(Ljava/lang/String;Lio/sqreen/powerwaf/"
+                                "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
+                                "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
+                                "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
+                                "RuleSetInfo$SectionInfo;Lio/sqreen/powerwaf/"
+                                "RuleSetInfo$SectionInfo;)V",
+                                JMETHOD_CONSTRUCTOR)) {
+        goto err;
+    }
+    if (!java_meth_init_checked(env, &_sect_info_err_init,
+                                "io/sqreen/powerwaf/RuleSetInfo$SectionInfo",
+                                "<init>", "(Ljava/lang/String;)V",
+                                JMETHOD_CONSTRUCTOR)) {
+        goto err;
+    }
+    if (!java_meth_init_checked(
+                env, &_sect_info_normal_init,
+                "io/sqreen/powerwaf/RuleSetInfo$SectionInfo", "<init>",
+                "(Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V",
+                JMETHOD_CONSTRUCTOR)) {
+        goto err;
+    }
+    if (!java_meth_init_checked(env, &_array_list_init, "java/util/ArrayList",
+                                "<init>", "(I)V", JMETHOD_CONSTRUCTOR)) {
+        goto err;
+    }
+    if (!java_meth_init_checked(env, &_array_list_add, "java/util/ArrayList",
+                                "add", "(Ljava/lang/Object;)Z",
+                                JMETHOD_NON_VIRTUAL)) {
+        goto err;
+    }
+    if (!java_meth_init_checked(env, &_linked_hm_init,
+                                "java/util/LinkedHashMap", "<init>", "()V",
+                                JMETHOD_CONSTRUCTOR)) {
+        goto err;
+    }
+    if (!java_meth_init_checked(
+                env, &_map_put, "java/util/Map", "put",
+                "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                JMETHOD_VIRTUAL)) {
+        goto err;
+    }
+
+    return;
+err:
+    output_shutdown(env);
+}
+
+void output_shutdown(JNIEnv *env)
+{
+    java_meth_destroy(env, &_rsi_init);
+    java_meth_destroy(env, &_sect_info_err_init);
+    java_meth_destroy(env, &_sect_info_normal_init);
+    java_meth_destroy(env, &_array_list_init);
+    java_meth_destroy(env, &_array_list_add);
+    java_meth_destroy(env, &_linked_hm_init);
+    java_meth_destroy(env, &_map_put);
+}
+
+static const ddwaf_object *_map_get_object_checked(JNIEnv *env,
+                                                   const ddwaf_object *obj,
+                                                   const char *str,
+                                                   size_t str_len)
+{
+    if (!obj || obj->type != DDWAF_OBJ_MAP) {
+        JNI(ThrowNew, jcls_rte, "ddwaf map expected");
+        return NULL;
+    }
+
+    for (uint64_t i = 0; i < obj->nbEntries; i++) {
+        const ddwaf_object *o = &obj->array[i];
+        if (o->parameterNameLength == str_len &&
+            memcmp(o->parameterName, str, str_len) == 0) {
+            return o;
+        }
+    }
+    return NULL;
+}
+
+static jstring _map_get_string_checked(JNIEnv *env, const ddwaf_object *obj,
+                                       const char *str, size_t str_len)
+{
+    const ddwaf_object *o = _map_get_object_checked(env, obj, str, str_len);
+    if (JNI(ExceptionCheck) || o == NULL) {
+        return NULL;
+    }
+
+    size_t length;
+    const char *value = ddwaf_object_get_string(o, &length);
+    if (!value) {
+        JNI(ThrowNew, jcls_rte, "ddwaf string expected");
+        return NULL;
+    }
+
+    return java_utf8_to_jstring_checked(env, value, length);
+}
+
+static jobject _convert_strarr_checked(JNIEnv *env, const ddwaf_object *o)
+{
+    if (!o) {
+        return NULL;
+    }
+
+    if (o->type != DDWAF_OBJ_ARRAY) {
+        JNI(ThrowNew, jcls_rte, "ddwaf array expected");
+        return NULL;
+    }
+
+    if (o->nbEntries == 0) {
+        return NULL;
+    }
+
+    if (o->nbEntries > MAX_JINT) {
+        JNI(ThrowNew, jcls_rte, "too many elements in ddwaf array");
+        return NULL;
+    }
+
+    jobject ret =
+            java_meth_call(env, &_array_list_init, NULL, (jint) o->nbEntries);
+    if (ret == NULL) {
+        return NULL;
+    }
+
+    for (uint64_t i = 0; i < o->nbEntries; i++) {
+        const ddwaf_object *elem = &o->array[i];
+        size_t str_len;
+        const char *str = ddwaf_object_get_string(elem, &str_len);
+        if (!str) {
+            JNI(ThrowNew, jcls_rte, "expected array to contain only strings");
+            goto err;
+        }
+
+        jstring jstr = java_utf8_to_jstring_checked(env, str, str_len);
+        if (JNI(ExceptionCheck)) {
+            goto err;
+        }
+        java_meth_call(env, &_array_list_add, ret, jstr);
+        JNI(DeleteLocalRef, jstr);
+        if (JNI(ExceptionCheck)) {
+            goto err;
+        }
+    }
+
+    return ret;
+
+err:
+    JNI(DeleteLocalRef, ret);
+    return NULL;
+}
+
+static jobject _map_get_object_strarr_checked(JNIEnv *env,
+                                              const ddwaf_object *obj,
+                                              const char *str, size_t str_len)
+{
+
+    const ddwaf_object *o = _map_get_object_checked(env, obj, str, str_len);
+    if (JNI(ExceptionCheck) || o == NULL) {
+        return NULL;
+    }
+
+    return _convert_strarr_checked(env, o);
+}
+
+static jobject _map_get_object_errmap_checked(JNIEnv *env,
+                                              const ddwaf_object *obj,
+                                              const char *str, size_t str_len)
+{
+    const ddwaf_object *o = _map_get_object_checked(env, obj, str, str_len);
+    if (JNI(ExceptionCheck) || o == NULL) {
+        return NULL;
+    }
+
+    if (o->type != DDWAF_OBJ_MAP) {
+        JNI(ThrowNew, jcls_rte, "ddwaf map expected");
+        return NULL;
+    }
+
+    if (o->nbEntries == 0) {
+        return NULL;
+    }
+
+    jobject ret = java_meth_call(env, &_linked_hm_init, NULL);
+    if (JNI(ExceptionCheck)) {
+        return NULL;
+    }
+
+    for (uint64_t i = 0; i < o->nbEntries; i++) {
+        ddwaf_object *elem = &o->array[i];
+        if (elem->type != DDWAF_OBJ_ARRAY) {
+            JNI(ThrowNew, jcls_rte, "ddwaf array expected inside map");
+            goto err;
+        }
+
+        jstring jkey = java_utf8_to_jstring_checked(env, elem->parameterName,
+                                                    elem->parameterNameLength);
+        if (JNI(ExceptionCheck)) {
+            goto err;
+        }
+        jobject str_list = _convert_strarr_checked(env, elem);
+        if (JNI(ExceptionCheck)) {
+            JNI(DeleteLocalRef, jkey);
+            goto err;
+        }
+
+        java_meth_call(env, &_map_put, ret, jkey, str_list);
+        JNI(DeleteLocalRef, jkey);
+        JNI(DeleteLocalRef, str_list);
+        if (JNI(ExceptionCheck)) {
+            goto err;
+        }
+    }
+
+    return ret;
+err:
+    JNI(DeleteLocalRef, ret);
+    return NULL;
+}
+
+static jobject _convert_section_checked(JNIEnv *env, const ddwaf_object *root,
+                                        const char *sect_name, size_t sect_len)
+{
+    const ddwaf_object *section =
+            _map_get_object_checked(env, root, sect_name, sect_len);
+    if (JNI(ExceptionCheck) || section == NULL) {
+        return NULL;
+    }
+
+    {
+        jstring error = _map_get_string_checked(env, section, LSTR("error"));
+        if (JNI(ExceptionCheck)) {
+            return NULL;
+        }
+
+        if (error) {
+            jobject res =
+                    java_meth_call(env, &_sect_info_err_init, NULL, error);
+            JNI(DeleteLocalRef, error);
+            return res;
+        }
+    }
+
+    jobject loaded = NULL, failed = NULL, errors = NULL, ret = NULL;
+
+    loaded = _map_get_object_strarr_checked(env, section, LSTR("loaded"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+    failed = _map_get_object_strarr_checked(env, section, LSTR("failed"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+    errors = _map_get_object_errmap_checked(env, section, LSTR("errors"));
+    if (JNI(ExceptionCheck)) {
+        goto err;
+    }
+
+    ret = java_meth_call(env, &_sect_info_normal_init, NULL, loaded, failed,
+                         errors);
+
+err:
+    if (loaded) {
+        JNI(DeleteLocalRef, loaded);
+    }
+    if (failed) {
+        JNI(DeleteLocalRef, failed);
+    }
+    if (errors) {
+        JNI(DeleteLocalRef, errors);
+    }
+    return ret;
+}
+
+struct json_segment *output_convert_json(const ddwaf_object *obj)
+{
+    struct json_segment *initial_seg = json_seg_new(0);
+    if (!initial_seg) {
+        return NULL;
+    }
+    bool ok = _convert_json(obj, 0, initial_seg) != NULL;
+    if (ok) {
+        return initial_seg;
+    } else {
+        json_seg_free(initial_seg);
+        return NULL;
+    }
+}
+
+static struct json_segment *_convert_json(const ddwaf_object *cur_obj,
+                                          int depth,
+                                          struct json_segment *cur_seg)
+{
+    if (depth > MAX_JSON_DEPTH || !cur_obj || !cur_seg) {
+        return NULL;
+    }
+
+    switch (cur_obj->type) {
+    case DDWAF_OBJ_INVALID:
+        return false;
+    case DDWAF_OBJ_SIGNED: {
+        int64_t val = cur_obj->intValue;
+        char str[21];
+        int len = sprintf(str, "%" PRId64, val);
+        assert(len > 0); // can't fail
+        cur_seg = json_append(cur_seg, str, (size_t) len);
+    } break;
+    case DDWAF_OBJ_UNSIGNED: {
+        uint64_t val = cur_obj->uintValue;
+        char str[21];
+        int len = sprintf(str, "%" PRIu64, val);
+        assert(len > 0); // can't fail
+        cur_seg = json_append(cur_seg, str, (size_t) len);
+    } break;
+    case DDWAF_OBJ_STRING: {
+        cur_seg = json_append(cur_seg, "\"", 1);
+        cur_seg = json_encode_str(cur_seg, cur_obj->stringValue,
+                                  cur_obj->nbEntries);
+        cur_seg = json_append(cur_seg, "\"", 1);
+    } break;
+    case DDWAF_OBJ_ARRAY: {
+        cur_seg = json_append(cur_seg, "[", 1);
+        for (uint64_t i = 0; i < cur_obj->nbEntries; i++) {
+            const ddwaf_object *o = &cur_obj->array[i];
+            cur_seg = _convert_json(o, depth + 1, cur_seg);
+            if (i != cur_obj->nbEntries - 1) {
+                cur_seg = json_append(cur_seg, ",", 1);
+            }
+        }
+        cur_seg = json_append(cur_seg, "]", 1);
+    } break;
+    case DDWAF_OBJ_MAP: {
+        cur_seg = json_append(cur_seg, "{", 1);
+        for (uint64_t i = 0; i < cur_obj->nbEntries; i++) {
+            const ddwaf_object *o = &cur_obj->array[i];
+
+            cur_seg = json_append(cur_seg, "\"", 1);
+            cur_seg = json_encode_str(cur_seg, o->parameterName,
+                                      o->parameterNameLength);
+            cur_seg = json_append(cur_seg, "\":", 2);
+
+            cur_seg = _convert_json(o, depth + 1, cur_seg);
+
+            if (i != cur_obj->nbEntries - 1) {
+                cur_seg = json_append(cur_seg, ",", 1);
+            }
+        }
+        cur_seg = json_append(cur_seg, "}", 1);
+    } break;
+    case DDWAF_OBJ_BOOL: {
+        if (cur_obj->boolean) {
+            cur_seg = json_append(cur_seg, "true", 4);
+        } else {
+            cur_seg = json_append(cur_seg, "false", 5);
+        }
+    } break;
+    }
+
+    return cur_seg;
+}

--- a/src/main/c/output.h
+++ b/src/main/c/output.h
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache-2.0 License.
+ *
+ * This product includes software developed at Datadog
+ * (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
+ */
+
+#pragma once
+
+#include <jni.h>
+#include <ddwaf.h>
+
+#include "json.h"
+
+// Schemas: https://github.com/DataDog/libddwaf/tree/master/schema
+
+void output_init_checked(JNIEnv *env);
+void output_shutdown(JNIEnv *env);
+jobject output_convert_diagnostics_checked(JNIEnv *env,
+                                           const ddwaf_object *obj);
+
+struct json_segment *output_convert_json(const ddwaf_object *obj);

--- a/src/main/c/utf16_utf8.h
+++ b/src/main/c/utf16_utf8.h
@@ -12,10 +12,12 @@
 #include <jni.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "json.h"
 
 void java_utf16_to_utf8_checked(JNIEnv *env, const jchar *in, jsize length, uint8_t **out_p, size_t *out_len_p);
 jstring java_utf8_to_jstring_checked(JNIEnv *env, const char *in, size_t in_len);
 char *java_to_utf8_checked(JNIEnv *env, jstring str, size_t *utf8_out_len);
-char *java_to_utf8_limited_checked( JNIEnv *env, jstring str, size_t *len, int max_len);
+char *java_to_utf8_limited_checked(JNIEnv *env, jstring str, size_t *len, int max_len);
+jstring java_json_to_jstring_checked(JNIEnv *env, const struct json_segment *seg);
 
 #endif

--- a/src/main/java/io/sqreen/powerwaf/Powerwaf.java
+++ b/src/main/java/io/sqreen/powerwaf/Powerwaf.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 public final class Powerwaf {
-    public static final String LIB_VERSION = "1.10.0";
+    public static final String LIB_VERSION = "1.11.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Powerwaf.class);
     static final boolean ENABLE_BYTE_BUFFERS;

--- a/src/main/java/io/sqreen/powerwaf/RuleSetInfo.java
+++ b/src/main/java/io/sqreen/powerwaf/RuleSetInfo.java
@@ -8,30 +8,137 @@
 
 package io.sqreen.powerwaf;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RuleSetInfo {
-    public final String fileVersion;
-    public final int numRulesOK;
-    public final int numRulesError;
-    // map error string -> array of rule ids
-    public final Map<String, String[]> errors;
+    public static class SectionInfo {
+        private final String error;
+        private final List<String> loaded;
+        private final List<String> failed;
+        // map error string -> array of rule ids
+        private final Map<String, List<String>> errors;
 
-    public RuleSetInfo(String fileVersion, int numRulesOK, int numRulesError, Map<String, String[]> errors) {
-        this.fileVersion = fileVersion;
-        this.numRulesOK = numRulesOK;
-        this.numRulesError = numRulesError;
-        this.errors = errors;
+        public SectionInfo(String error) {
+            this.error = error;
+            this.loaded = null;
+            this.failed = null;
+            this.errors = null;
+        }
+
+        public SectionInfo(List<String> loaded, List<String> failed, Map<String, List<String>> errors) {
+            this.error = null;
+            this.loaded = loaded;
+            this.failed = failed;
+            this.errors = errors;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+        public List<String> getLoaded() {
+            if (loaded == null) {
+                return Collections.emptyList();
+            }
+            return loaded;
+        }
+
+        public List<String> getFailed() {
+            if (failed == null) {
+                return Collections.emptyList();
+            }
+            return failed;
+        }
+
+        public Map<String, List<String>> getErrors() {
+            if (errors == null) {
+                return Collections.emptyMap();
+            }
+            return errors;
+        }
+
+        @Override
+        public String toString() {
+            if (error != null) {
+                return new StringJoiner(", ", SectionInfo.class.getSimpleName() + "[", "]")
+                        .add("error=" + error)
+                        .toString();
+            }
+            return new StringJoiner(", ", SectionInfo.class.getSimpleName() + "[", "]")
+                    .add("loaded=" + loaded)
+                    .add("failed=" + failed)
+                    .add("errors=" + errors)
+                    .toString();
+        }
+    }
+
+
+    public final String rulesetVersion;
+    public final SectionInfo rules;
+    public final SectionInfo customRules;
+    public final SectionInfo rulesData;
+    public final SectionInfo rulesOverride;
+    public final SectionInfo exclusions;
+
+    public RuleSetInfo(String rulesetVersion, SectionInfo rules, SectionInfo customRules, SectionInfo rulesData, SectionInfo rulesOverride, SectionInfo exclusions) {
+        this.rulesetVersion = rulesetVersion;
+        this.rules = rules;
+        this.customRules = customRules;
+        this.rulesData = rulesData;
+        this.rulesOverride = rulesOverride;
+        this.exclusions = exclusions;
+    }
+
+    public int getNumRulesOK() {
+        int count = 0;
+        if (this.rules != null) {
+            count += this.rules.getLoaded().size();
+        }
+        if (this.customRules != null) {
+            count += this.customRules.getLoaded().size();
+        }
+
+        return count;
+    }
+
+    public int getNumRulesError() {
+        int count = 0;
+        if (this.rules != null) {
+            count += this.rules.getFailed().size();
+        }
+        if (this.customRules != null) {
+            count += this.customRules.getFailed().size();
+        }
+
+        return count;
+    }
+
+    public Map<String, List<String>> getErrors() {
+        return Stream.of(this.rules, this.customRules)
+                .filter(Objects::nonNull)
+                .map(r -> r.getErrors())
+                .flatMap(e -> e.entrySet().stream())
+                .collect(Collectors.toMap(
+                        e -> e.getKey(),
+                        e -> e.getValue(),
+                        (l1, l2) -> Stream.concat(l1.stream(), l2.stream()).collect(Collectors.toList())));
     }
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("RuleSetInfo{");
-        sb.append("fileVersion='").append(fileVersion).append('\'');
-        sb.append(", numRulesOK=").append(numRulesOK);
-        sb.append(", numRulesError=").append(numRulesError);
-        sb.append(", errors=").append(errors);
-        sb.append('}');
-        return sb.toString();
+        return new StringJoiner(", ", RuleSetInfo.class.getSimpleName() + "[", "]")
+                .add("rulesetVersion='" + rulesetVersion + "'")
+                .add("rules=" + rules)
+                .add("customRules=" + customRules)
+                .add("rulesData=" + rulesData)
+                .add("rulesOverride=" + rulesOverride)
+                .add("exclusions=" + exclusions)
+                .toString();
     }
 }

--- a/src/test/groovy/io/sqreen/powerwaf/BadRuleTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/BadRuleTests.groovy
@@ -34,7 +34,21 @@ class BadRuleTests implements PowerwafTrait {
         def rsi = exc.ruleSetInfo
         assert rsi.numRulesOK == 0
         assert rsi.numRulesError == 1
-        assert rsi.errors == [:]
+        assert rsi.errors == ['missing key \'id\'':['index:0']]
+    }
+
+    @Test
+    void 'rules have the wrong form'() {
+        def rules = copyMap(ARACHNI_ATOM_V2_1)
+        rules['rules'] = [:]
+        InvalidRuleSetException exc = shouldFail(InvalidRuleSetException) {
+            ctx = Powerwaf.createContext('test', rules)
+        }
+
+        def rsi = exc.ruleSetInfo
+        assert rsi.numRulesOK == 0
+        assert rsi.numRulesError == 0
+        assert rsi.rules.error == "bad cast, expected 'array', obtained 'map'"
     }
 
     @Test

--- a/src/test/groovy/io/sqreen/powerwaf/BasicTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/BasicTests.groovy
@@ -50,10 +50,11 @@ class BasicTests implements PowerwafTrait {
         assert json[0].rule_matches[0]['parameters'][0].highlight == ['Arachni']
 
         def rsi = ctx.ruleSetInfo
+        assert rsi.rules.loaded == ['arachni_rule']
         assert rsi.numRulesOK == 1
         assert rsi.numRulesError == 0
         assert rsi.errors == [:]
-        assert rsi.fileVersion == null
+        assert rsi.rulesetVersion == null
     }
 
     @Test
@@ -83,7 +84,7 @@ class BasicTests implements PowerwafTrait {
         assert rsi.numRulesOK == 1
         assert rsi.numRulesError == 0
         assert rsi.errors == [:]
-        assert rsi.fileVersion == '1.2.6'
+        assert rsi.rulesetVersion == '1.2.6'
 
         assert metrics.totalRunTimeNs > 0
         assert metrics.totalDdwafRunTimeNs > 0
@@ -413,7 +414,7 @@ class BasicTests implements PowerwafTrait {
         ]
         ctx.withCloseable {
             ctx = ctx.update('test2', overrideSpec)
-            assertThat ctx.ruleSetInfo.fileVersion, is('1.2.7')
+            assertThat ctx.ruleSetInfo.rulesetVersion, is('1.2.7')
         }
         Powerwaf.ResultWithData awd = ctx.runRules(
                 ['server.request.headers.no_cookies': ['user-agent': 'Arachni/v1']], limits, metrics)

--- a/src/test/groovy/io/sqreen/powerwaf/InvalidInvocationTests.groovy
+++ b/src/test/groovy/io/sqreen/powerwaf/InvalidInvocationTests.groovy
@@ -19,7 +19,7 @@ import java.nio.ByteBuffer
 
 import static groovy.test.GroovyAssert.shouldFail
 import static org.hamcrest.MatcherAssert.assertThat
-import static org.hamcrest.Matchers.arrayContaining
+import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.equalTo
 import static org.hamcrest.Matchers.hasEntry
@@ -151,7 +151,7 @@ class InvalidInvocationTests implements ReactiveTrait {
         assertThat exc.ruleSetInfo.numRulesOK, equalTo(0)
         assertThat exc.ruleSetInfo.errors, hasEntry(
                 equalTo('missing key \'conditions\''),
-                arrayContaining(equalTo('foobar'))
+                contains(equalTo('foobar'))
         )
         assertThat exc.message, containsString('Call to ddwaf_update failed')
     }


### PR DESCRIPTION
Two outputs were changed in 1.11.0:

* ddwaf_init/update now returns diagnostics in a new schema, and in the form of ddwaf_object, rather than the custom struct used before. In this PR, the ddwaf_object is used to create java objects matching the schema of the diagnostics.
* ddwaf_run no longer returns the matches in json, and uses ddwaf_object instead. Here, instead of serializing into a set of java objects, I chose to preserve json output by converting the ddwaf_object into a json string. This is simpler to implement and probably faster, as calling many Java methods from JNI is slow.