### PR TITLE
Run CI on master and PRs, not branches

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,8 @@
 name: Build Native Libraries
 on:
   pull_request:
-    branches: '*'
   push:
-    branches-ignore: '*'
+    branches: [ master ]
     tags: '*'
 defaults:
   run:


### PR DESCRIPTION
This will avoid duplicate workflows for every push on a PR.